### PR TITLE
fix: pin correct branch and commit for FasterLivePortrait dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN pip3 install --no-cache-dir \
       ${TensorRT_ROOT}/python/tensorrt-10.9.0.34-cp310-none-linux_x86_64.whl
 
 RUN git clone https://github.com/SeanWangJS/grid-sample3d-trt-plugin.git /grid-sample3d-trt-plugin
-RUN git clone https://github.com/varshith15/FasterLivePortrait.git /FasterLivePortrait
+RUN git clone --branch vbrealtime_upgrade https://github.com/varshith15/FasterLivePortrait.git /FasterLivePortrait
 
 WORKDIR /FasterLivePortrait
 RUN huggingface-cli download warmshao/FasterLivePortrait \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Improve mouth tracking with live AI Video"
 version = "0.0.1"
 license = { file = "LICENSE" }
 dependencies = [
-    "faster-live-portrait @ git+https://github.com/varshith15/FasterLivePortrait@7614dbe20ebc2a6586d83e7352a82031e3ecca7a",
+    "faster-live-portrait @ git+https://github.com/varshith15/FasterLivePortrait@5e545c4b112ac6f0011f8a9fe11bb67f7481a5a5",
 ]
 
 [project.optional-dependencies]

--- a/scripts/build_fasterliveportrait_trt.sh
+++ b/scripts/build_fasterliveportrait_trt.sh
@@ -25,7 +25,7 @@ else
 fi
 
 if [ ! -d "$FLP_DIR/.git" ]; then
-    git clone https://github.com/varshith15/FasterLivePortrait.git "$FLP_DIR"
+    git clone --branch vbrealtime_upgrade https://github.com/varshith15/FasterLivePortrait.git "$FLP_DIR"
 else
     echo "✅ $FLP_DIR already exists, skipping clone."
 fi


### PR DESCRIPTION
This pull request fixes a bug which caused, the code to clone the `master` branch of [varshith15/FasterLivePortrait](https://github.com/varshith15/FasterLivePortrait), where we intended to use the `vbrealtime_upgrade` branch. Additionally, the `pyproject.toml` referenced an incorrect commit. This update ensures the correct branch and commit are pinned to avoid inconsistencies.