### PR TITLE
Ps/update single param on change

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -14,6 +14,22 @@ class FasterLivePortrait:
                 "target": ("IMAGE",),
             },
             "optional": {
+                "flag_normalize_lip": ("BOOLEAN", {"default": False}),
+                "flag_source_video_eye_retargeting": ("BOOLEAN", {"default": False}),
+                "flag_video_editing_head_rotation": ("BOOLEAN", {"default": False}),
+                "flag_eye_retargeting": ("BOOLEAN", {"default": False}),
+                "flag_lip_retargeting": ("BOOLEAN", {"default": False}),
+                "flag_stitching": ("BOOLEAN", {"default": True}),
+                "flag_pasteback": ("BOOLEAN", {"default": True}),
+                "flag_do_crop": ("BOOLEAN", {"default": True}),
+                "flag_do_rot": ("BOOLEAN", {"default": True}),
+                "lip_normalize_threshold": ("FLOAT", {"default": 0.1, "min": 0.0, "max": 1.0, "step": 0.01}),
+                "driving_multiplier": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 10.0, "step": 0.1}),
+                "animation_region": (["lip", "full"], {"default": "lip"}), # currently only works for lip
+                "cfg_mode": (["incremental", "reference"], {"default": "incremental"}),
+                "cfg_scale": ("FLOAT", {"default": 1.2, "min": 0.0, "max": 10.0, "step": 0.1}),
+                "source_max_dim": ("INT", {"default": 1280, "min": 64, "step": 8}),
+                "source_division": ("INT", {"default": 2, "min": 1, "max": 8, "step": 1})
             },
         }
 
@@ -25,7 +41,8 @@ class FasterLivePortrait:
         config_dict = get_live_portrait_config()
         self.pipeline = FasterLivePortraitPipeline(cfg=OmegaConf.create(config_dict), is_animal=False)
 
-    def process_image(self, source, target):
+    def process_image(self, source, target, **kwargs):
+        self.pipeline.update_cfg(kwargs)
         source_np = tensor_to_cv2(source)
         target_np = tensor_to_cv2(target)
         processed_image = self.pipeline.animate_image(source_np, target_np)

--- a/nodes.py
+++ b/nodes.py
@@ -40,9 +40,32 @@ class FasterLivePortrait:
     def __init__(self):
         config_dict = get_live_portrait_config()
         self.pipeline = FasterLivePortraitPipeline(cfg=OmegaConf.create(config_dict), is_animal=False)
+        self._last_cfg_inputs = {}
+        self._cfg_keys = [
+            "flag_normalize_lip",
+            "flag_source_video_eye_retargeting",
+            "flag_video_editing_head_rotation",
+            "flag_eye_retargeting",
+            "flag_lip_retargeting",
+            "flag_stitching",
+            "flag_pasteback",
+            "flag_do_crop",
+            "flag_do_rot",
+            "lip_normalize_threshold",
+            "driving_multiplier",
+            "animation_region",
+            "cfg_mode",
+            "cfg_scale",
+            "source_max_dim",
+            "source_division"
+        ]
 
     def process_image(self, source, target, **kwargs):
-        self.pipeline.update_cfg(kwargs)
+        for k in self._cfg_keys:
+            new_val = kwargs[k]
+            if self._last_cfg_inputs.get(k) != new_val:
+                self.pipeline.set_cfg_param(k, new_val)
+                self._last_cfg_inputs[k] = new_val
         source_np = tensor_to_cv2(source)
         target_np = tensor_to_cv2(target)
         processed_image = self.pipeline.animate_image(source_np, target_np)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Improve mouth tracking with live AI Video"
 version = "0.0.1"
 license = { file = "LICENSE" }
 dependencies = [
-    "faster-live-portrait @ git+https://github.com/varshith15/FasterLivePortrait@5e545c4b112ac6f0011f8a9fe11bb67f7481a5a5",
+    "faster-live-portrait @ git+https://github.com/pschroedl/FasterLivePortrait@2f0f32531501689fb06d9586969e85800ae9aa98",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-faster-live-portrait @ git+https://github.com/varshith15/FasterLivePortrait@5e545c4b112ac6f0011f8a9fe11bb67f7481a5a5
+faster-live-portrait @ git+https://github.com/pschroedl/FasterLivePortrait@2f0f32531501689fb06d9586969e85800ae9aa98


### PR DESCRIPTION
Updating via update_cfg produces excessive logging and appears to lose ~3fps.

Using a new method to only update one parameter at a time allows us to inexpensively check for changes in the ComfyUI-FasterLivePortrait node and only apply changes to the intended parameter.

Changes to pyproject.toml and requirements.txt are only to test in comfystream and can be reverted once https://github.com/varshith15/FasterLivePortrait/pull/1 is merged